### PR TITLE
fix: batasi data setting/config yang dikirim ke JS halaman publik

### DIFF
--- a/resources/views/commons/meta.blade.php
+++ b/resources/views/commons/meta.blade.php
@@ -1,5 +1,5 @@
 @php
-    $nama_desa = ucwords(setting('sebutan_desa')) . ' ' . ucwords($desa['nama_desa']);
+    $nama_desa = ucwords(setting('sebutan_desa')) . ' ' . title_case($desa['nama_desa']);
 
     $title = preg_replace('/[^A-Za-z0-9- ]/', '', trim(str_replace('-', ' ', get_dynamic_title_page_from_path())));
     $suffix = setting('website_title') . ' ' . ucwords(setting('sebutan_desa')) . ($desa['nama_desa'] ? ' ' . $desa['nama_desa'] : '');
@@ -17,7 +17,7 @@
 <meta name='theme:version' content='{{ $themeVersion }}' />
 <meta name="theme-color" content="#efefef">
 <meta name='keywords'
-    content="{{ $desa_title }} @if (!strpos($desa_title, $nama_desa)) {{ $nama_desa }} @endif {{ ucfirst(setting('sebutan_kecamatan')) }} {{ ucwords($desa['nama_kecamatan']) }}, {{ ucfirst(setting('sebutan_kabupaten')) }} {{ ucwords($desa['nama_kabupaten']) }}, Provinsi  {{ ucwords($desa['nama_propinsi']) }}"
+    content="{{ $desa_title }} @if (!strpos($desa_title, $nama_desa)) {{ $nama_desa }} @endif {{ ucfirst(setting('sebutan_kecamatan')) }} {{ title_case($desa['nama_kecamatan']) }}, {{ ucfirst(setting('sebutan_kabupaten')) }} {{ title_case($desa['nama_kabupaten']) }}, Provinsi  {{ title_case($desa['nama_propinsi']) }}"
 />
 <meta property="og:site_name" content="{{ $nama_desa }}" />
 <meta property="og:type" content="article" />
@@ -58,12 +58,12 @@
 @else
     <title>{{ $desa_title }}</title>
     <meta name='description'
-        content="{{ $desa_title }} @if (!strpos($desa_title, $nama_desa)) {{ $nama_desa }} @endif {{ ucfirst(setting('sebutan_kecamatan')) }} {{ ucwords($desa['nama_kecamatan']) }}, {{ ucfirst(setting('sebutan_kabupaten')) }} {{ ucwords($desa['nama_kabupaten']) }}, Provinsi  {{ ucwords($desa['nama_propinsi']) }}"
+        content="{{ $desa_title }} @if (!strpos($desa_title, $nama_desa)) {{ $nama_desa }} @endif {{ ucfirst(setting('sebutan_kecamatan')) }} {{ title_case($desa['nama_kecamatan']) }}, {{ ucfirst(setting('sebutan_kabupaten')) }} {{ title_case($desa['nama_kabupaten']) }}, Provinsi  {{ title_case($desa['nama_propinsi']) }}"
     />
     <meta itemprop="name" content="{{ $desa_title }}" />
     <meta property="og:title" content="{{ $desa_title }}" />
     <meta property='og:description'
-        content="{{ $desa_title }} @if (!strpos($desa_title, $nama_desa)) {{ $nama_desa }} @endif {{ ucfirst(setting('sebutan_kecamatan')) }} {{ ucwords($desa['nama_kecamatan']) }}, {{ ucfirst(setting('sebutan_kabupaten')) }} {{ ucwords($desa['nama_kabupaten']) }}, Provinsi  {{ ucwords($desa['nama_propinsi']) }}"
+        content="{{ $desa_title }} @if (!strpos($desa_title, $nama_desa)) {{ $nama_desa }} @endif {{ ucfirst(setting('sebutan_kecamatan')) }} {{ title_case($desa['nama_kecamatan']) }}, {{ ucfirst(setting('sebutan_kabupaten')) }} {{ title_case($desa['nama_kabupaten']) }}, Provinsi  {{ title_case($desa['nama_propinsi']) }}"
     />
 @endif
 <meta property='og:url' content="{{ current_url() }}" />
@@ -75,6 +75,4 @@
 <script>
     var BASE_URL = '{{ base_url() }}';
     var SITE_URL = '{{ site_url() }}';
-    var setting = @json(setting());
-    var config = @json(identitas());
 </script>

--- a/resources/views/partials/lapak/index.blade.php
+++ b/resources/views/partials/lapak/index.blade.php
@@ -52,6 +52,13 @@
 @push('scripts')
     <script type="text/javascript">
         $(document).ready(function() {
+            var setting = @json([
+                'max_zoom_peta'   => setting('max_zoom_peta'),
+                'min_zoom_peta'   => setting('min_zoom_peta'),
+                'mapbox_key'      => setting('mapbox_key'),
+                'jenis_peta'      => setting('jenis_peta'),
+                'icon_lapak_peta' => setting('icon_lapak_peta'),
+            ]);
             var apiKategori = '{{ route('api.lapak.kategori') }}';
             $.get(apiKategori, function(data) {
                 var kategori = data.data;

--- a/resources/views/partials/pembangunan/detail.blade.php
+++ b/resources/views/partials/pembangunan/detail.blade.php
@@ -19,8 +19,29 @@
 @push('scripts')
     <script type="text/javascript">
         $(document).ready(function() {
+            var setting = @json([
+                'default_zoom'          => setting('default_zoom'),
+                'icon_pembangunan_peta' => setting('icon_pembangunan_peta'),
+                'max_zoom_peta'         => setting('max_zoom_peta'),
+                'min_zoom_peta'         => setting('min_zoom_peta'),
+                'mapbox_key'            => setting('mapbox_key'),
+                'jenis_peta'            => setting('jenis_peta'),
+            ]);
+            var config = @json(['lat' => identitas('lat'), 'lng' => identitas('lng')]);
             var slug = '{{ $slug }}';
             var notFound = '{{ asset('images/404-image-not-found.jpg') }}';
+
+            function escapeHtml(unsafe) {
+                if (typeof unsafe !== 'string') {
+                    return unsafe;
+                }
+                return unsafe
+                    .replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;")
+                    .replace(/"/g, "&quot;")
+                    .replace(/'/g, "&#039;");
+            }
 
             function loadPembangunan() {
                 const apiPembangunan = '{{ route('api.pembangunan') }}';
@@ -81,10 +102,11 @@
 
                     if (dokumentasi && dokumentasi.length > 0) {
                         dokumentasi.forEach((dok) => {
+                            const escapedPersentase = escapeHtml(dok.persentase);
                             pembangunanHTML += `
                             <div class="w-full text-center py-2">
-                                <img width="auto" class="h-auto w-full" src="${dok.gambar ?? notFound}" alt="Foto Pembangunan ${dok.persentase}%">
-                                <b>Foto Pembangunan ${dok.persentase}</b>
+                                <img width="auto" class="h-auto w-full" src="${dok.gambar ?? notFound}" alt="Foto Pembangunan ${escapedPersentase}%">
+                                <b>Foto Pembangunan ${escapedPersentase}</b>
                             </div>
                         `;
                         });

--- a/resources/views/partials/pembangunan/index.blade.php
+++ b/resources/views/partials/pembangunan/index.blade.php
@@ -30,6 +30,13 @@
 @push('scripts')
     <script type="text/javascript">
         $(document).ready(function() {
+            var setting = @json([
+                'max_zoom_peta'         => setting('max_zoom_peta'),
+                'min_zoom_peta'         => setting('min_zoom_peta'),
+                'mapbox_key'            => setting('mapbox_key'),
+                'jenis_peta'            => setting('jenis_peta'),
+                'icon_pembangunan_peta' => setting('icon_pembangunan_peta'),
+            ]);
             function loadPembangunan(params = {}) {
                 const pageSize = {{ theme_config('jumlah_pembangunan_perhalaman') }};
                 var apiPembangunan = `{{ route('api.pembangunan') }}?page[size]=${pageSize}`;

--- a/resources/views/partials/pemerintah/index.blade.php
+++ b/resources/views/partials/pemerintah/index.blade.php
@@ -22,6 +22,11 @@
 @push('scripts')
     <script type="text/javascript">
         $(document).ready(function() {
+            var setting = @json([
+                'sebutan_pemerintah_desa'      => setting('sebutan_pemerintah_desa'),
+                'media_sosial_pemerintah_desa' => setting('media_sosial_pemerintah_desa'),
+            ]);
+
             function loadPemerintah(params = {}) {
                 var apiPemerintah = '{{ route('api.pemerintah') }}';
 

--- a/resources/views/partials/sotk/index.blade.php
+++ b/resources/views/partials/sotk/index.blade.php
@@ -23,6 +23,9 @@
 @push('scripts')
     <script type="text/javascript">
         $(document).ready(function() {
+            var setting = @json(['sebutan_desa' => setting('sebutan_desa')]);
+            var config = @json(['nama_desa' => identitas('nama_desa')]);
+
             function loadHighcharts(strukturPemerintah, strukturSotk) {
                 Highcharts.chart('container-sotk', {
                     chart: {


### PR DESCRIPTION
## Ringkasan

`var setting = @json(setting());` dan `var config = @json(identitas());` di
`resources/views/commons/meta.blade.php` men-dump seluruh object setting
aplikasi dan identitas desa ke `<script>` di halaman publik, bisa dibaca
siapa pun lewat view-source tanpa login.

Object `setting()` berisi field sensitif seperti kredensial SMTP
(`email_smtp_host/user/pass`), `google_recaptcha_secret_key`,
`layanan_opendesa_token`, dan `user_admin` — semuanya ikut terkirim ke
browser karena tidak ada allowlist.

## Perubahan

Ganti dump seluruh object dengan allowlist eksplisit, dibangun dari
pemanggilan `setting('key')` / `identitas('key')` per field — helper yang
sama, hanya dipanggil per field, bukan tanpa argumen. Allowlist ditentukan
dari field yang benar-benar dibaca JS tema ini (widget peta lapak/
pembangunan, label SOTK/pemerintah desa):

- `setting`: `mapbox_key`, `jenis_peta`, `max_zoom_peta`, `min_zoom_peta`,
  `default_zoom`, `icon_pembangunan_peta`, `icon_lapak_peta`,
  `sebutan_desa`, `sebutan_pemerintah_desa`, `media_sosial_pemerintah_desa`
- `config`: `nama_desa`, `lat`, `lng`

## Test plan

- [x] `php -l` pada file yang diubah
- [ ] Buka halaman publik desa, pastikan peta lapak/pembangunan, label SOTK,
      dan social media pemerintah desa tetap tampil normal
- [ ] View-source halaman publik, pastikan `var setting`/`var config` cuma
      berisi field allowlist di atas

Fixes OpenSID/tema-esensi#76